### PR TITLE
Fixing npm audit [semver-major]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 node_modules
-test-fixtures
-coverage
-*.bak
-*.log
+package-lock.json
+test/dir/change

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: node_js
 node_js:
-- 'stable'
-- '4'
-- '0.12'
-- '0.10'
-notifications:
-  email:
-  - kimmobrunfeldt+chokidar@gmail.com
+- 'node'
+- '10'
+- '8'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,16 +5,12 @@ Please follow existing code style and commit message conventions.
 Remember to keep documentation updated.
 
 **Pull requests:** You don't need to bump version numbers or modify anything
-related to releasing. That stuff is fully automated, just write the functionality.
+related to releasing. A maintainer will do this when its time to release.
 
 # Maintaining
 
 ## Release
 
 * Commit all changes
-* Run `./node_modules/.bin/releasor --bump minor`, which will create new tag and publish code to GitHub and npm
-
-    See [releasor documentation](https://github.com/kimmobrunfeldt/releasor)
-    for detailed usage.
-
+* Create new tag and publish code to GitHub and npm
 * Edit GitHub release notes

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-var Promise = require('bluebird');
-var _ = require('lodash');
+const debounce = require('lodash.debounce');
+const throttle = require('lodash.throttle');
 var chokidar = require('chokidar');
 var spawn = require('npm-run-all/lib/spawn').default;
 
@@ -136,7 +136,7 @@ var argv = require('yargs')
 
 function main() {
     var userOpts = getUserOpts(argv);
-    var opts = _.merge(defaultOpts, userOpts);
+    var opts = Object.assign({}, defaultOpts, userOpts);
     startWatching(opts);
 }
 
@@ -149,7 +149,7 @@ function startWatching(opts) {
     var child;
     var chokidarOpts = createChokidarOpts(opts);
     var watcher = chokidar.watch(opts.patterns, chokidarOpts);
-    var execFn = _.debounce(_.throttle(function(event, path) {
+    var execFn = debounce(throttle(function(event, path) {
         if (child) child.removeAllListeners();
         child = spawn(SHELL_PATH, [
             EXECUTE_OPTION,
@@ -163,7 +163,7 @@ function startWatching(opts) {
 
     watcher.on('all', function(event, path) {
         var description = EVENT_DESCRIPTIONS[event] + ':';
-        var executeCommand = _.partial(execFn, event, path);
+        var executeCommand = () => execFn(event, path);
 
         if (opts.verbose) {
             console.error(description, path);
@@ -220,9 +220,9 @@ function _resolveIgnoreOpt(ignoreOpt) {
         return ignoreOpt;
     }
 
-    var ignores = !_.isArray(ignoreOpt) ? [ignoreOpt] : ignoreOpt;
+    var ignores = !Array.isArray(ignoreOpt) ? [ignoreOpt] : ignoreOpt;
 
-    return _.map(ignores, function(ignore) {
+    return ignores.map(function(ignore) {
         var isRegex = ignore[0] === '/' && ignore[ignore.length - 1] === '/';
         if (isRegex) {
             // Convert user input to regex object

--- a/package.json
+++ b/package.json
@@ -36,19 +36,13 @@
     "anymatch": "^1.1.0",
     "bluebird": "^2.9.24",
     "chokidar": "^1.0.1",
-    "lodash": "^3.7.0",
+    "lodash.debounce": "^4.0.8",
+    "lodash.throttle": "^4.1.1",
     "npm-run-all": "1.6.0",
-    "shell-quote": "^1.4.3",
     "yargs": "^3.7.2"
   },
   "devDependencies": {
-    "commander": "^2.8.0",
-    "mocha": "^2.2.4",
-    "mustache": "^2.0.0",
-    "releasor": "^1.2.1",
-    "semver": "^4.3.3",
-    "shelljs": "^0.4.0",
-    "string": "^3.1.1"
+    "mocha": "^5.2.0"
   },
   "scripts": {
     "test": "mocha"

--- a/test/test-all.js
+++ b/test/test-all.js
@@ -109,7 +109,8 @@ describe('chokidar-cli', function() {
         })
         .then(function childProcessExited(exitCode) {
             done();
-        });
+        })
+        .catch(done);
 
         setTimeout(function afterWatchIsReady() {
             fs.writeFileSync(resolve('dir/subdir/c.less'), 'content');
@@ -142,7 +143,8 @@ describe('chokidar-cli', function() {
         })
         .then(function childProcessExited(exitCode) {
             done();
-        });
+        })
+        .catch(done);
 
         setTimeout(function afterWatchIsReady() {
             fs.writeFileSync(resolve('dir/subdir/c.less'), 'content');

--- a/test/test-all.js
+++ b/test/test-all.js
@@ -2,7 +2,6 @@
 
 var fs = require('fs');
 var path = require('path');
-var exec = require('child_process').exec;
 var assert = require('assert');
 var utils = require('../utils');
 var run = utils.run;

--- a/utils.js
+++ b/utils.js
@@ -1,7 +1,4 @@
 var childProcess = require('child_process');
-var _ = require('lodash');
-var Promise = require('bluebird');
-var shellQuote = require('shell-quote');
 
 // Try to resolve path to shell.
 // We assume that Windows provides COMSPEC env variable
@@ -17,7 +14,7 @@ function run(cmd, opts) {
         throw new Error('$SHELL environment variable is not set.');
     }
 
-    opts = _.merge({
+    opts = Object.assign({}, {
         pipe: true,
         cwd: undefined,
         callback: function(child) {


### PR DESCRIPTION
This commit updates (and removes) many dependencies. As a result, all
non-current node versions (<6) are now unsupported.

* The `.gitignore` file is cleaned up.
* The TravisCI config is updated to reflect only the supported versions and no longer notify previous maintainer.
* The `releasor` dependency is removed because it caused audit issues.
* `debounce` and `throttle` are imported from the non-monolithic `lodash` packages.
* other uses of `lodash` refactored away using modern JS.
* removed a ton of unused `dependencies` and `devDependencies`.
* updated version of `mocha` to resolve audit issues.